### PR TITLE
Format empty price (false) on import

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
     ]
   },
   "extra":{
+    "branch-alias": {
+      "dev-main": "1.0.x-dev"
+    },
     "contao-manager-plugin": "ContaoEstateManager\\WibImport\\ContaoManager\\Plugin"
   }
 }

--- a/src/Resources/contao/classes/WibImport.php
+++ b/src/Resources/contao/classes/WibImport.php
@@ -204,6 +204,18 @@ class WibImport extends System
         }
     }
 
+    /**
+     * Formats a non-given main price to the correct value as
+     * WIB does not comply with OpenImmo standard
+     */
+    public function formatEmptyMainPrice(&$objRealEstate, $context): void
+    {
+        if (false === $objRealEstate->kaufpreis)
+        {
+            $objRealEstate->kaufpreis = null;
+        }
+    }
+
     protected function getValueFromStringUrl($url, $parameter)
     {
         $parts = parse_url($url);

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -20,4 +20,5 @@ if(AddonManager::valid()) {
     $GLOBALS['TL_HOOKS']['realEstateImportBeforeCronSync'][]   = array(WibImport::class, 'downloadOpenImmoFile');
     $GLOBALS['TL_HOOKS']['realEstateImportPrePrepareRecord'][] = array(WibImport::class, 'skipPartnerRecord');
     $GLOBALS['TL_HOOKS']['realEstateImportSaveImage'][]        = array(WibImport::class, 'downloadImage');
+    $GLOBALS['TL_HOOKS']['beforeRealEstateImport'][]           = array(WibImport::class, 'formatEmptyMainPrice');
 }


### PR DESCRIPTION
<h3>Bugfix</h3>

- catches an empty (false) main price as wib sometimes does not comply with OpenImmo standard https://github.com/contao-estatemanager/wib-import/commit/6695aeadca6b4619974ae8c01b547257ea2a7196